### PR TITLE
md5未指定编码

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -467,9 +467,9 @@ var ucfirst = exports.ucfirst = function(name){
  * @param  {[type]} str [description]
  * @return {[type]}     [description]
  */
-var md5 = exports.md5 = function(str){
+var md5 = exports.md5 = function(str, encoding){
   var instance = crypto.createHash('md5');
-  instance.update(str + '');
+  instance.update(str + '', encoding);
   return instance.digest('hex');
 };
 /**


### PR DESCRIPTION
当str中含有中文字符时，如果没有指定编码，会采用默认的'binaery'编码，导致结果不一致
